### PR TITLE
add typings to getRelation() function

### DIFF
--- a/packages/dart/lib/src/objects/parse_object.dart
+++ b/packages/dart/lib/src/objects/parse_object.dart
@@ -312,8 +312,8 @@ class ParseObject extends ParseBase implements ParseCloneable {
   }
 
   /// Get the instance of ParseRelation class associated with the given key.
-  ParseRelation getRelation(String key) {
-    return ParseRelation(parent: this, key: key);
+  ParseRelation<T> getRelation<T extends ParseObject>(String key) {
+    return ParseRelation<T>(parent: this, key: key);
   }
 
   /// Removes an element from an Array


### PR DESCRIPTION
Adding typings to ParseObject's getRelation method. 